### PR TITLE
Remove redundant Docker image removal commands from CI/CD scripts

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -82,8 +82,6 @@ jobs:
             echo "MAIL_PASSWORD=${{ secrets.MAIL_PASSWORD }}" >> .env
             echo "MAIL_FROM=${{ secrets.MAIL_FROM }}" >> .env
             docker compose -f docker-compose.prod.yml down
-            docker rmi ghcr.io/${{ github.repository }}/backend:latest
-            docker rmi ghcr.io/${{ github.repository }}/frontend:latest
             docker compose -f docker-compose.prod.yml pull
             docker compose -f docker-compose.prod.yml up -d
             cd /home/vmv94/gateway/

--- a/.github/workflows/deploy-on-sbi.yml
+++ b/.github/workflows/deploy-on-sbi.yml
@@ -35,6 +35,6 @@ jobs:
             echo "MAIL_USERNAME=${{ secrets.MAIL_USERNAME }}" >> .env.backend
             echo "MAIL_PASSWORD=${{ secrets.MAIL_PASSWORD }}" >> .env.backend
             echo "MAIL_FROM=${{ secrets.MAIL_FROM }}" >> .env.backend
-            docker compose -f docker-compose.sbi.yml down --rmi 
+            docker compose -f docker-compose.sbi.yml down
             docker compose -f docker-compose.sbi.yml pull
             docker compose -f docker-compose.sbi.yml up -d

--- a/.github/workflows/deploy-on-sbi.yml
+++ b/.github/workflows/deploy-on-sbi.yml
@@ -35,8 +35,6 @@ jobs:
             echo "MAIL_USERNAME=${{ secrets.MAIL_USERNAME }}" >> .env.backend
             echo "MAIL_PASSWORD=${{ secrets.MAIL_PASSWORD }}" >> .env.backend
             echo "MAIL_FROM=${{ secrets.MAIL_FROM }}" >> .env.backend
-            docker compose -f docker-compose.sbi.yml down
-            docker rmi ghcr.io/akarmanov2022/track-me/backend:latest
-            docker rmi ghcr.io/akarmanov2022/track-me/frontend:latest
+            docker compose -f docker-compose.sbi.yml down --rmi 
             docker compose -f docker-compose.sbi.yml pull
             docker compose -f docker-compose.sbi.yml up -d


### PR DESCRIPTION
This pull request includes changes to the Docker compose commands in the GitHub workflows for building and deploying artifacts. The main updates involve removing specific Docker image removal commands and modifying the `docker compose down` command to also remove images.

Changes to Docker compose commands:

* [`.github/workflows/build-artifacts.yml`](diffhunk://#diff-b42f740b4418aaeb96e2db7ca7816039f8cfb34d8e1e4a4b7519d540b34a2a08L85-L86): Removed the commands to explicitly remove the backend and frontend Docker images.
* [`.github/workflows/deploy-on-sbi.yml`](diffhunk://#diff-25448742f401b1ffc70a17f1efd7f7f0dc8d7494d68b52a6621bf951acc84d6bL38-R38): Removed the commands to explicitly remove the backend and frontend Docker images and modified the `docker compose down` command to include the `--rmi` option, which removes images.