### PR TITLE
Add Trackme Report Service with containerization workflow

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -100,6 +100,34 @@ jobs:
             ghcr.io/${{ github.repository }}/gateway:${{ github.ref_name }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+  trackme-report-service-build-push:
+    needs: changes
+    if: needs.changes.outputs.gateway == 'true' || github.ref_type == 'tag'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver: docker-container
+      - name: Build and Push trackme-report-service Image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: services/trackme-report-service/Dockerfile
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}/report-service:latest
+            ghcr.io/${{ github.repository }}/report-service:${{ github.sha }}
+            ghcr.io/${{ github.repository }}/report-service:${{ github.ref_name }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
   trackme-sso-build-push:
     needs: changes

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -57,15 +57,12 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: |
           pwd; ls -l .
-          JACOCO_PATH1="$GITHUB_WORKSPACE/apps/backend/build/reports/jacoco/test/jacocoTestReport.xml"
-          JACOCO_PATH2="$GITHUB_WORKSPACE/services/trackme-sso/build/reports/jacoco/test/jacocoTestReport.xml"
           ./gradlew build sonar \
             -Dsonar.projectKey=${{ secrets.SONAR_BACKEND_PROJECT_KEY }} \
             -Dsonar.token=${{ secrets.SONAR_TOKEN }} \
             -Dsonar.pullrequest.key=${{ github.event.pull_request.number }} \
             -Dsonar.pullrequest.branch=${{ github.head_ref }} \
             -Dsonar.pullrequest.base=${{ github.base_ref }} \
-            -Dsonar.coverage.jacoco.xmlReportPaths=$JACOCO_PATH1,$JACOCO_PATH2 \
 
   frontend-sonar:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -64,7 +64,7 @@ jobs:
             -Dsonar.pullrequest.branch=${{ github.head_ref }} \
             -Dsonar.pullrequest.base=${{ github.base_ref }} \
             -Dsonar.log.level=DEBUG
-            -Dsonar.sources=src/main/java,src/main/resources
+            -Dsonar.sources=apps/*/src/main/java,apps/*/src/main/resources,services/*/src/main/java,services/*/src/main/resources
 
   frontend-sonar:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -63,7 +63,7 @@ jobs:
             -Dsonar.pullrequest.key=${{ github.event.pull_request.number }} \
             -Dsonar.pullrequest.branch=${{ github.head_ref }} \
             -Dsonar.pullrequest.base=${{ github.base_ref }} \
-            -Dsonar.log.level=DEBUG
+            -Dsonar.log.level=DEBUG \
             -Dsonar.sources=apps/*/src/main/java,apps/*/src/main/resources,services/*/src/main/java,services/*/src/main/resources
 
   frontend-sonar:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -63,6 +63,7 @@ jobs:
             -Dsonar.pullrequest.key=${{ github.event.pull_request.number }} \
             -Dsonar.pullrequest.branch=${{ github.head_ref }} \
             -Dsonar.pullrequest.base=${{ github.base_ref }} \
+            -Dsonar.log.level=DEBUG
 
   frontend-sonar:
     runs-on: ubuntu-latest
@@ -105,7 +106,7 @@ jobs:
             -Dsonar.exclusions="src/**/*.test.js,src/**/*.spec.js,src/**/__tests__/**" \
             -Dsonar.javascript.lcov.reportPaths=coverage/lcov.info \
             -Dsonar.host.url=https://sonarcloud.io \
-            -Dsonar.login=${{ secrets.SONAR_TOKEN }} \
+            -Dsonar.token=${{ secrets.SONAR_TOKEN }} \
             -Dsonar.pullrequest.key=${{ github.event.pull_request.number }} \
             -Dsonar.pullrequest.branch=${{ github.head_ref }} \
             -Dsonar.pullrequest.base=${{ github.base_ref }}

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -64,6 +64,7 @@ jobs:
             -Dsonar.pullrequest.branch=${{ github.head_ref }} \
             -Dsonar.pullrequest.base=${{ github.base_ref }} \
             -Dsonar.log.level=DEBUG
+            -Dsonar.sources=src/main/java,src/main/resources
 
   frontend-sonar:
     runs-on: ubuntu-latest

--- a/services/trackme-report-service/Dockerfile
+++ b/services/trackme-report-service/Dockerfile
@@ -1,0 +1,31 @@
+# ----------- Build stage -----------
+FROM gradle:8-jdk21-alpine AS builder
+
+WORKDIR /app
+
+# 1. Копируем только файлы зависимостей и wrapper для кеша Gradle
+COPY build.gradle settings.gradle gradle /app/
+COPY services/trackme-report-service/build.gradle /app/services/trackme-report-service/
+
+# 2. Прогреваем зависимости (кеширует максимально)
+RUN --mount=type=cache,target=/root/.gradle gradle :trackme-report-service:dependencies --no-daemon
+
+# 3. Копируем исходники только нужного приложения и его зависимости
+COPY services/trackme-report-service /app/services/trackme-report-service
+
+# 4. Сборка JAR (кешируется благодаря шагам выше)
+RUN --mount=type=cache,target=/root/.gradle gradle :trackme-report-service:clean :trackme-report-service:bootJar --no-daemon
+
+# ----------- Runtime stage -----------
+FROM eclipse-temurin:21-jre-alpine
+
+WORKDIR /app
+
+# Не-root пользователь и curl (в 1 слой)
+RUN addgroup -S appgroup && adduser -S appuser -G appgroup && apk add --no-cache curl
+USER appuser
+
+COPY --from=builder /app/apps/trackme-report-service/build/libs/trackme-report-service-*.jar app.jar
+
+EXPOSE 8080
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/services/trackme-report-service/build.gradle
+++ b/services/trackme-report-service/build.gradle
@@ -1,0 +1,40 @@
+plugins {
+    id 'java'
+    id 'org.springframework.boot'
+    id 'jacoco'
+    id 'io.spring.dependency-management'
+}
+
+version = '0.0.1-SNAPSHOT'
+
+springBoot {
+    buildInfo()
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    developmentOnly 'org.springframework.boot:spring-boot-devtools'
+    developmentOnly 'org.springframework.boot:spring-boot-docker-compose'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+}
+
+test {
+    useJUnitPlatform()
+    finalizedBy jacocoTestReport
+}
+
+jacocoTestReport {
+    dependsOn test
+    reports {
+        xml.required = true
+        html.required = true
+    }
+}
+

--- a/services/trackme-report-service/build.gradle
+++ b/services/trackme-report-service/build.gradle
@@ -19,10 +19,16 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.apache.poi:poi-ooxml:5.4.0'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'
+
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     developmentOnly 'org.springframework.boot:spring-boot-docker-compose'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
 }
 
 test {

--- a/services/trackme-report-service/src/main/java/net/akarmanov/projectplace/trackmereportservice/TrackmeReportServiceApplication.java
+++ b/services/trackme-report-service/src/main/java/net/akarmanov/projectplace/trackmereportservice/TrackmeReportServiceApplication.java
@@ -1,0 +1,13 @@
+package net.akarmanov.projectplace.trackmereportservice;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class TrackmeReportServiceApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(TrackmeReportServiceApplication.class, args);
+    }
+
+}

--- a/services/trackme-report-service/src/main/java/net/akarmanov/projectplace/trackmereportservice/config/SecurityConfiguration.java
+++ b/services/trackme-report-service/src/main/java/net/akarmanov/projectplace/trackmereportservice/config/SecurityConfiguration.java
@@ -1,0 +1,30 @@
+package net.akarmanov.projectplace.trackmereportservice.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfiguration {
+    @Bean
+    SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .cors(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests(auth ->
+                        auth
+                                .requestMatchers("/api/v1/report/excel").authenticated()
+                                .requestMatchers(
+                                        "/swagger-ui/**",
+                                        "/swagger-resources/*",
+                                        "/actuator/**",
+                                        "/v3/api-docs/**",
+                                        "/v3/api-docs.yaml/**",
+                                        "/v3/api-docs.yaml").permitAll()
+                                .anyRequest().permitAll());
+        return http.build();
+    }
+}

--- a/services/trackme-report-service/src/main/java/net/akarmanov/projectplace/trackmereportservice/controllers/ReportController.java
+++ b/services/trackme-report-service/src/main/java/net/akarmanov/projectplace/trackmereportservice/controllers/ReportController.java
@@ -1,0 +1,19 @@
+package net.akarmanov.projectplace.trackmereportservice.controllers;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.core.io.Resource;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@RequestMapping("/api/v1/reports")
+@Tag(name = "Report API", description = "API для генерации отчетов")
+public interface ReportController {
+    @Operation(summary = "Генерация отчета в формате Excel",
+            description = "Генерация отчета в формате Excel")
+    @GetMapping(path = "/main/excel",
+            produces = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
+    ResponseEntity<Resource> generateExcelReport(Authentication authentication);
+}

--- a/services/trackme-report-service/src/main/java/net/akarmanov/projectplace/trackmereportservice/controllers/ReportControllerImpl.java
+++ b/services/trackme-report-service/src/main/java/net/akarmanov/projectplace/trackmereportservice/controllers/ReportControllerImpl.java
@@ -1,0 +1,16 @@
+package net.akarmanov.projectplace.trackmereportservice.controllers;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.io.Resource;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class ReportControllerImpl implements ReportController {
+    @Override
+    public ResponseEntity<Resource> generateExcelReport(Authentication authentication) {
+        return ResponseEntity.ok().build();
+    }
+}

--- a/services/trackme-report-service/src/main/resources/application.yml
+++ b/services/trackme-report-service/src/main/resources/application.yml
@@ -1,0 +1,3 @@
+spring:
+  application:
+    name: trackme-report-service

--- a/services/trackme-report-service/src/main/resources/application.yml
+++ b/services/trackme-report-service/src/main/resources/application.yml
@@ -1,3 +1,8 @@
 spring:
   application:
     name: trackme-report-service
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          issuer-uri: ${SSO_URI:http://localhost:9000}

--- a/services/trackme-report-service/src/test/java/net/akarmanov/projectplace/trackmereportservice/TrackmeReportServiceApplicationTests.java
+++ b/services/trackme-report-service/src/test/java/net/akarmanov/projectplace/trackmereportservice/TrackmeReportServiceApplicationTests.java
@@ -1,0 +1,21 @@
+package net.akarmanov.projectplace.trackmereportservice;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContext;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@SpringBootTest
+class TrackmeReportServiceApplicationTests {
+
+    @Autowired
+    private ApplicationContext applicationContext;
+
+    @Test
+    void contextLoads() {
+        assertNotNull(applicationContext, "Application context should not be null");
+    }
+
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -9,6 +9,9 @@ project(':frontend').projectDir = file('apps/frontend')
 include ':trackme-gateway'
 project(':trackme-gateway').projectDir = file('apps/trackme-gateway')
 
+include ':trackme-report-service'
+project(':trackme-report-service').projectDir = file('services/trackme-report-service')
+
 include ':trackme-sso'
 project(':trackme-sso').projectDir = file('services/trackme-sso')
 


### PR DESCRIPTION
```
### Summary

This pull request introduces the Trackme Report Service as a new Spring Boot application. It includes the following key changes:

- **Project Setup**: Added the initial setup for the Trackme Report Service, including its build configuration, Gradle dependencies, Dockerfile, and test setup.
- **Workflow Integration**: Implemented a GitHub Actions workflow to build and push the `trackme-report-service` Docker image to the GitHub Container Registry.
- **Code Cleanup**: Removed unused JaCoCo report paths configuration from the Sonar workflow script to streamline the CI process.

### Checklist

- [ ] Unit tests added/updated
- [ ] Documentation updated
- [ ] All tests passed locally
```